### PR TITLE
feat(CommentAppService) : 댓글, 답글 비지니스 로직 추가

### DIFF
--- a/seboard/src/main/java/com/seproject/seboard/application/CommentAppService.java
+++ b/seboard/src/main/java/com/seproject/seboard/application/CommentAppService.java
@@ -1,35 +1,198 @@
 package com.seproject.seboard.application;
 
+import com.seproject.seboard.domain.model.Author;
+import com.seproject.seboard.domain.model.Comment;
+import com.seproject.seboard.domain.model.Post;
+import com.seproject.seboard.domain.model.UnnamedComment;
+import com.seproject.seboard.domain.repository.AuthorRepository;
+import com.seproject.seboard.domain.repository.CommentRepository;
+import com.seproject.seboard.domain.repository.PostRepository;
+import com.seproject.seboard.domain.repository.UnnamedCommentRepository;
+import com.seproject.seboard.dto.CommentDTO;
+import com.seproject.seboard.dto.ReplyDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.security.Key;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
 public class CommentAppService {
 
+    private final UnnamedCommentRepository unnamedCommentRepository;
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final AuthorRepository authorRepository;
+
     public void createNamedComment(Long userId, Long postId, String contents){
+        Author author = findByIdOrThrow(userId, authorRepository, "");
+        Post post = findByIdOrThrow(postId,postRepository,"");
+
+        Comment comment = Comment.builder()
+                .post(post)
+                .author(author)
+                .contents(contents)
+                .build();
+
+        commentRepository.save(comment);
     }
 
-    public void createUnnamedComment(Long postId, String contents, String password){
+    public void createUnnamedComment(Long postId, String contents,String username, String password){
+        Post post = findByIdOrThrow(postId,postRepository,"");
+
+        Author author = Author.builder()
+                .loginId(Author.ANONYMOUS_LOGIN_ID)
+                .name(username)
+                .build();
+
+        UnnamedComment comment = UnnamedComment.builder()
+                .post(post)
+                .author(author)
+                .contents(contents)
+                .password(password)
+                .build();
+
+        unnamedCommentRepository.save(comment);
     }
 
-    public void createNamedReply(Long userId, Long postId, Long commentId, String contents){
+    public void createNamedReply(Long userId, Long postId, Long commentId, Long taggedCommentId,String contents){
+        Post post = findByIdOrThrow(postId,postRepository,"");
+        Comment superComment = findByIdOrThrow(commentId,commentRepository,"");
+        Comment taggedComment = findByIdOrThrow(taggedCommentId,commentRepository,"");
+        Author author = findByIdOrThrow(userId, authorRepository,"");
+
+        Comment reply = Comment.builder()
+                .post(post)
+                .author(author)
+                .superComment(superComment)
+                .tag(taggedComment)
+                .contents(contents)
+                .build();
+
+        commentRepository.save(reply);
     }
 
-    public void createUnnamedReply(Long postId, Long commentId, String contents, String password){
+
+    public void createUnnamedReply(Long postId, Long commentId,Long taggedCommentId, String contents,String username, String password){
+        Post post = findByIdOrThrow(postId,postRepository,"");
+
+        Author author = Author.builder()
+                .loginId(Author.ANONYMOUS_LOGIN_ID)
+                .name(username)
+                .build();
+
+        Comment superComment = findByIdOrThrow(commentId,commentRepository,"");
+        Comment taggedComment = findByIdOrThrow(taggedCommentId,commentRepository,"");
+
+        UnnamedComment unnamedComment = UnnamedComment.builder()
+                .post(post)
+                .author(author)
+                .superComment(superComment)
+                .tag(taggedComment)
+                .contents(contents)
+                .password(password)
+                .build();
+
+        unnamedCommentRepository.save(unnamedComment);
     }
 
     // Retrieve -> Comment만
     //TODO : void -> 변경필요
-    public void retrieveCommentList(Long postId){
+    public List<CommentDTO.CommentListResponseDTO> retrieveCommentList(Long postId,Long userId){
         //TODO : pagination 고려
+
+        Author requestUser = findByIdOrThrow(userId,authorRepository,"");
+
+        //TODO : JPQL 최적화 고려,
+        // 정렬 방법 -> superComment 생성 시간순으로 정렬 -> 자신의 생성 시간순으로 정렬
+        // 이렇게 하면 댓글 -> 답글 , 댓글 -> 답글 순으로 정렬 가능, 방법은 JPQL 만들고 결정해야할듯
+        List<Comment> comments = commentRepository.findByPostId(postId);
+        Collections.sort(comments);
+
+        List<CommentDTO.CommentListResponseDTO> result = new ArrayList<>();
+
+        for (int i = 0; i < comments.size();) {
+            Comment superComment = comments.get(i);
+            List<Comment> replies = new ArrayList<>();
+            i++;
+            for (;  i < comments.size(); i++) {
+                Comment reply = comments.get(i);
+                if(reply.isReply()) replies.add(reply);
+                else break;
+            }
+
+            List<ReplyDTO.ReplyResponseDTO> repliesDTO = replies.stream().map(reply -> {
+                boolean isEditable = reply.isWrittenBy(requestUser);
+                return ReplyDTO.ReplyResponseDTO.toDTO(reply,isEditable);
+            }).collect(Collectors.toList());
+            boolean isEditable = superComment.isWrittenBy(requestUser);
+            CommentDTO.CommentListResponseDTO commentDTO = CommentDTO.CommentListResponseDTO.toDTO(superComment,isEditable,repliesDTO);
+            result.add(commentDTO);
+        }
+
+        return result;
+
+        /*
+        return comments.stream().map(comment -> {
+            boolean isEditable = comment.isWrittenBy(requestUser);
+            List<Comment> replies = commentRepository.findRepliesBySuperCommentId(comment.getSuperComment().getCommentId());
+            List<ReplyDTO.ReplyResponseDTO> replyResponseDTOS = replies.stream().map(reply -> {
+                boolean isEditableReply = reply.isWrittenBy(requestUser);
+                return ReplyDTO.ReplyResponseDTO.toDTO(reply, isEditableReply);
+            }).collect(Collectors.toList());
+            return CommentDTO.CommentListResponseDTO.toDTO(comment,isEditable,replyResponseDTOS);
+        }).collect(Collectors.toList());
+        */
     }
 
     public void changeContentsOfNamed(Long commentId, Long userId, String contents){
+        Comment comment = findByIdOrThrow(commentId,commentRepository,"");
+        Author requestUser = findByIdOrThrow(userId,authorRepository,"");
+
+        if(comment.isNamed() && comment.isWrittenBy(requestUser)) {
+            comment.change(contents);
+        }
+        //작성자가 다른 경우, 또는 익명 게시글이 선택된 경우
+        throw new IllegalArgumentException();
     }
 
     public void changeContentsOfUnnamed(Long commentId, String password, String contents){
+        UnnamedComment unnamedComment = findByIdOrThrow(commentId,unnamedCommentRepository,"");
+
+        if(unnamedComment.checkPassword(password)) {
+            unnamedComment.change(contents);
+        }
+
+        // 패스워드가 다른 경우
+        throw new IllegalArgumentException();
     }
 
     public void deleteNamedComment(Long commentId, Long userId){
+        Comment comment = findByIdOrThrow(commentId,commentRepository,"");
+        Author requestUser = findByIdOrThrow(userId,authorRepository,"");
+
+        if (comment.isWrittenBy(requestUser)) {
+            commentRepository.delete(comment);
+        }
+
+        // 작성자가 다른 경우
+        throw new IllegalArgumentException();
     }
 
     public void deleteUnnamedComment(Long commentId, String password){
+        UnnamedComment unnamedComment = findByIdOrThrow(commentId,unnamedCommentRepository,"");
+
+        if (unnamedComment.checkPassword(password)) {
+            unnamedCommentRepository.delete(unnamedComment);
+        }
+
+        // 패스워드가 다른 경우
+        throw new IllegalArgumentException();
+    }
+
+    private <T> T findByIdOrThrow(Long id, JpaRepository<T, Long> repo, String errorMsg){
+        return repo.findById(id).orElseThrow(() -> new NoSuchElementException(errorMsg));
     }
     
 }

--- a/seboard/src/main/java/com/seproject/seboard/domain/model/Comment.java
+++ b/seboard/src/main/java/com/seproject/seboard/domain/model/Comment.java
@@ -1,9 +1,11 @@
 package com.seproject.seboard.domain.model;
 
+import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
+@Getter
 @SuperBuilder
-public class Comment {
+public class Comment implements Comparable<Comment> {
     private Long commentId;
     private Post post;
     private Comment superComment;
@@ -19,5 +21,19 @@ public class Comment {
 
     public boolean isReply(){
         return superComment != null;
+    }
+
+    public void change(String contents) {
+        this.contents = contents;
+    }
+
+    public boolean isWrittenBy(Author author) {
+        return author.equals(this.author);
+    }
+
+
+    @Override
+    public int compareTo(Comment o) {
+        return o.compareTo(this);
     }
 }

--- a/seboard/src/main/java/com/seproject/seboard/domain/model/Comment.java
+++ b/seboard/src/main/java/com/seproject/seboard/domain/model/Comment.java
@@ -34,6 +34,25 @@ public class Comment implements Comparable<Comment> {
 
     @Override
     public int compareTo(Comment o) {
-        return o.compareTo(this);
+
+        Comment thisTarget = this;
+        Comment opposite = o;
+
+        boolean thisIsReply = isReply();
+        boolean targetIsReply = o.isReply();
+
+        if(thisIsReply) {
+            thisTarget = this.superComment;
+        }
+
+        if(targetIsReply) {
+            opposite = o.superComment;
+        }
+
+        if (thisIsReply && targetIsReply && thisTarget.equals(opposite)) {
+            return baseTime.getCreatedAt().compareTo(opposite.getBaseTime().getCreatedAt());
+        }
+
+        return thisTarget.baseTime.getCreatedAt().compareTo(opposite.getBaseTime().getCreatedAt());
     }
 }

--- a/seboard/src/main/java/com/seproject/seboard/domain/model/UnnamedComment.java
+++ b/seboard/src/main/java/com/seproject/seboard/domain/model/UnnamedComment.java
@@ -10,4 +10,8 @@ public class UnnamedComment extends Comment {
     public boolean isNamed() {
         return false;
     }
+
+    public boolean checkPassword(String password) {
+        return this.password.equals(password);
+    }
 }

--- a/seboard/src/main/java/com/seproject/seboard/domain/repository/CommentRepository.java
+++ b/seboard/src/main/java/com/seproject/seboard/domain/repository/CommentRepository.java
@@ -4,6 +4,10 @@ import com.seproject.seboard.domain.model.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment,Long> {
     int getCommentSizeByPostId(Long postId);
+    List<Comment> findByPostId(Long postId);
+    List<Comment> findRepliesBySuperCommentId(Long superCommentId);
 }

--- a/seboard/src/main/java/com/seproject/seboard/domain/repository/UnnamedCommentRepository.java
+++ b/seboard/src/main/java/com/seproject/seboard/domain/repository/UnnamedCommentRepository.java
@@ -1,0 +1,8 @@
+package com.seproject.seboard.domain.repository;
+
+import com.seproject.seboard.domain.model.UnnamedComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UnnamedCommentRepository extends JpaRepository<UnnamedComment,Long> {
+
+}

--- a/seboard/src/main/java/com/seproject/seboard/dto/CommentDTO.java
+++ b/seboard/src/main/java/com/seproject/seboard/dto/CommentDTO.java
@@ -1,0 +1,42 @@
+package com.seproject.seboard.dto;
+
+import com.seproject.seboard.domain.model.Author;
+import com.seproject.seboard.domain.model.Comment;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+public class CommentDTO {
+
+    @Data
+    @Builder
+    public static class CommentListResponseDTO {
+
+        private Long commentId;
+        private AuthorDTO.AuthorResponseDTO author;
+        private LocalDateTime createdAt;
+        private LocalDateTime modifiedAt;
+        private String contents;
+        private boolean isEditable;
+        private List<ReplyDTO.ReplyResponseDTO> replies;
+
+        public static CommentListResponseDTO toDTO(Comment comment, boolean isEditable, List<ReplyDTO.ReplyResponseDTO> repliesDTO) {
+            Author author = comment.getAuthor();
+            return builder()
+                    .commentId(comment.getCommentId())
+                    .author(AuthorDTO.AuthorResponseDTO.toDTO(author))
+                    .createdAt(comment.getBaseTime().getCreatedAt())
+                    .modifiedAt(comment.getBaseTime().getModifiedAt())
+                    .contents(comment.getContents())
+                    .isEditable(isEditable)
+                    .replies(repliesDTO)
+                    .build();
+        }
+    }
+
+
+}

--- a/seboard/src/main/java/com/seproject/seboard/dto/ReplyDTO.java
+++ b/seboard/src/main/java/com/seproject/seboard/dto/ReplyDTO.java
@@ -1,0 +1,36 @@
+package com.seproject.seboard.dto;
+
+import com.seproject.seboard.domain.model.Author;
+import com.seproject.seboard.domain.model.Comment;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+public class ReplyDTO {
+
+    @Data
+    @Builder(access = AccessLevel.PRIVATE)
+    public static class ReplyResponseDTO {
+        private Long commentId;
+        private AuthorDTO.AuthorResponseDTO author;
+        private LocalDateTime createdAt;
+        private LocalDateTime modifiedAt;
+        private String contents;
+        private boolean isEditable;
+
+        public static ReplyResponseDTO toDTO(Comment comment, boolean isEditable) {
+            Author author = comment.getAuthor();
+
+            return builder().commentId(comment.getCommentId())
+                    .author(AuthorDTO.AuthorResponseDTO.toDTO(author))
+                    .createdAt(comment.getBaseTime().getCreatedAt())
+                    .modifiedAt(comment.getBaseTime().getModifiedAt())
+                    .contents(comment.getContents())
+                    .isEditable(isEditable)
+                    .build();
+        }
+
+    }
+}

--- a/seboard/src/test/java/com/seproject/seboard/service/CommentAppServiceTest.java
+++ b/seboard/src/test/java/com/seproject/seboard/service/CommentAppServiceTest.java
@@ -1,0 +1,100 @@
+package com.seproject.seboard.service;
+
+import com.seproject.seboard.application.CommentAppService;
+import com.seproject.seboard.domain.model.Author;
+import com.seproject.seboard.domain.model.BaseTime;
+import com.seproject.seboard.domain.model.Comment;
+import com.seproject.seboard.domain.repository.AuthorRepository;
+import com.seproject.seboard.domain.repository.CommentRepository;
+import com.seproject.seboard.dto.CommentDTO;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class CommentAppServiceTest {
+
+
+    private CommentRepository commentRepository;
+    private AuthorRepository authorRepository;
+
+    private Author createAuthor(Long authorId,String loginId,String name) {
+        return Author.builder()
+                .authorId(authorId)
+                .loginId(loginId)
+                .name(name)
+                .build();
+    }
+
+    private Comment createMockComment(Long commentId, int year, int month, int day, Author author) {
+        return Comment.builder()
+                .commentId(commentId)
+                .author(author)
+                .baseTime(new BaseTime(LocalDateTime.of(year,month,day,0,0),null))
+                .build();
+    }
+
+    private Comment createMockReply(Long commentId, Comment superComment,Comment taggedComment, int year, int month, int day, Author author) {
+        return Comment.builder()
+                .commentId(commentId)
+                .superComment(superComment)
+                .tag(taggedComment)
+                .author(author)
+                .baseTime(new BaseTime(LocalDateTime.of(year,month,day,0,0),null))
+                .build();
+    }
+
+    @BeforeAll
+    public void init() {
+        commentRepository = mock(CommentRepository.class);
+        authorRepository = mock(AuthorRepository.class);
+
+        Author firstAuthor = createAuthor(1L, "hong", "홍길동");
+        Author secondAuthor = createAuthor(2L, "kim", "김민종");
+        Author thirdAuthor = createAuthor(3L, "lee", "이순신");
+
+        Comment first = createMockComment(1L,3022,11,13,firstAuthor);
+            Comment firstReply = createMockReply(4L,first,first,2021,11,4,secondAuthor);
+            Comment secondReply = createMockReply(5L,first,firstReply,300,2,11,thirdAuthor);
+        Comment second = createMockComment(2L,1021,11,13,secondAuthor);
+            Comment thirdReply = createMockReply(6L,second,second,1110,4,13,thirdAuthor);
+        Comment third = createMockComment(3L,2000,11,13,firstAuthor);
+
+        List<Comment> stub = List.of(first, second, third, firstReply, secondReply, thirdReply);
+
+        when(commentRepository.findByPostId(1L)).thenReturn(new ArrayList<>(stub));
+        when(authorRepository.findById(1L)).thenReturn(Optional.of(firstAuthor));
+    }
+    @Test
+    @DisplayName("게시글 상세 조회시 게시글에 달린 댓글들이 정상적으로 조회되는지 검사하는 기능")
+    void retrieveCommentListTest() {
+        CommentAppService commentAppService = new CommentAppService(null,commentRepository,null,authorRepository);
+        List<CommentDTO.CommentListResponseDTO> commentListResponseDTOS = commentAppService.retrieveCommentList(1L, 1L);
+        List<Integer> ans = List.of(1,0,2);
+
+        for (int i = 0; i < commentListResponseDTOS.size(); i++) {
+            CommentDTO.CommentListResponseDTO commentListResponseDTO = commentListResponseDTOS.get(i);
+            System.out.println(commentListResponseDTO);
+            commentListResponseDTO.getReplies().forEach(reply -> {
+                System.out.println("---> " + reply);
+            });
+            System.out.println("---------------------------");
+        }
+
+        for (int i = 0; i < 3; i++) {
+            CommentDTO.CommentListResponseDTO commentListResponseDTO = commentListResponseDTOS.get(i);
+            Assertions.assertThat(commentListResponseDTO.getReplies().size()).isEqualTo(ans.get(i));
+        }
+
+    }
+}


### PR DESCRIPTION
댓글, 답글과 관련된 기능을 구현함
게시물을 클릭했을때 댓글과, 답글을 조회하는 부분에서 쿼리가 너무 많이 나갈것 같아서 방법을 논의해야 할 듯 CommentDTO는 일반적인 DTO와 다르게 리스트 형태로 답글을 소유하게 만들었는데 이 부분도 논의가 필요해보임

addition :
    CommentAppService -> CRUD 기능 추가
    CommentDTO -> 게시글에 달린 댓글들을 전달하는 클래스 추가

retrieveCommentList 부분 테스트 작성중