### PR TITLE
fix : posts 검색 기능 카테고리 옵션 가능하게 변경

### DIFF
--- a/seboard/src/main/java/com/seproject/board/menu/domain/Menu.java
+++ b/seboard/src/main/java/com/seproject/board/menu/domain/Menu.java
@@ -30,7 +30,7 @@ public class Menu {
     private Long menuId;
     @ManyToOne
     @JoinColumn(name = "super_menu_id")
-    private Menu superMenu;
+    protected Menu superMenu;
     private String name;
     private String description;
     private int depth;

--- a/seboard/src/main/java/com/seproject/board/post/controller/PostSearchController.java
+++ b/seboard/src/main/java/com/seproject/board/post/controller/PostSearchController.java
@@ -18,29 +18,6 @@ public class PostSearchController {
     @GetMapping
     public ResponseEntity searchPosts(@ModelAttribute PostSearchRequest request,
                                       @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "25") int perPage) {
-        switch(PostSearchOptions.valueOf(request.getSearchOption())) {
-            case TITLE:{
-                Page<RetrievePostListResponseElement> res = postSearchAppService.searchByTitle(request.getQuery(), page, perPage);
-                return ResponseEntity.ok().body(res);
-            }
-            case CONTENT:{
-                Page<RetrievePostListResponseElement> res = postSearchAppService.searchByContent(request.getQuery(), page, perPage);
-                return ResponseEntity.ok().body(res);
-            }
-            case TITLE_OR_CONTENT:{
-                Page<RetrievePostListResponseElement> res = postSearchAppService.searchByTitleOrContent(request.getQuery(), page, perPage);
-                return ResponseEntity.ok().body(res);
-            }
-            case AUTHOR:{
-                Page<RetrievePostListResponseElement> res = postSearchAppService.searchByAuthorName(request.getQuery(), page, perPage);
-                return ResponseEntity.ok().body(res);
-            }
-            case ALL:{
-                Page<RetrievePostListResponseElement> res = postSearchAppService.searchByAll(request.getQuery(), page, perPage);
-                return ResponseEntity.ok().body(res);
-            }
-            default:
-                return ResponseEntity.badRequest().build();
-        }
+        return ResponseEntity.ok().body(postSearchAppService.searchPost(request, page, perPage));
     }
 }

--- a/seboard/src/main/java/com/seproject/board/post/controller/PostSearchOptions.java
+++ b/seboard/src/main/java/com/seproject/board/post/controller/PostSearchOptions.java
@@ -1,9 +1,29 @@
 package com.seproject.board.post.controller;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
+import lombok.Getter;
+
+import java.util.function.Function;
+
+import static com.seproject.board.post.domain.model.QPost.post;
+
+@Getter
 public enum PostSearchOptions {
-    TITLE,
-    CONTENT,
-    TITLE_OR_CONTENT,
-    AUTHOR,
-    ALL
+    TITLE(query -> post.title.contains(query)),
+    CONTENT(query -> post.contents.contains(query)),
+    TITLE_OR_CONTENT(query -> post.title.contains(query).or(post.contents.contains(query))),
+    AUTHOR(query -> post.author.name.contains(query)),
+    ALL(query -> post.title.contains(query)
+            .or(post.contents.contains(query))
+            .or(post.author.name.contains(query)));
+
+    PostSearchOptions(Function<String, BooleanExpression> searchOp) {
+        this.searchOp = searchOp;
+    }
+
+    private Function<String, BooleanExpression> searchOp;
+
+    public BooleanExpression search(String query){
+        return searchOp.apply(query);
+    }
 }

--- a/seboard/src/main/java/com/seproject/board/post/domain/repository/PostSearchRepository.java
+++ b/seboard/src/main/java/com/seproject/board/post/domain/repository/PostSearchRepository.java
@@ -19,13 +19,7 @@ public interface PostSearchRepository extends Repository<Post, Long> {
     Page<RetrievePostListResponseElement> findBookmarkPostByLoginId(String loginId, Pageable pagingInfo);
     Page<RetrievePostListResponseElement> findMemberPostByLoginId(String loginId, Pageable pagingInfo);
     Page<RetrievePostListResponseElement> findPostByLoginId(String loginId, Pageable pagingInfo);
-    Optional<RetrievePostDetailResponse> findPostDetailById(Long id);
     List<RetrievePostListResponseElement> findPinedPostByCategoryId(Long categoryId);
     Page<RetrievePostListResponseElement> findPostByCategoryId(Long categoryId, Pageable pagingInfo);
-    Page<RetrievePostListResponseElement> findByTitle(String title, Pageable pagingInfo);
-    Page<RetrievePostListResponseElement> findByContents(String content, Pageable pagingInfo);
-    Page<RetrievePostListResponseElement> findByTitleOrContents(String title, Pageable pagingInfo);
-    Page<RetrievePostListResponseElement> findByAuthorName(String authorName, Pageable pagingInfo);
-    Page<RetrievePostListResponseElement> findByAllOptions(String searchQuery, Pageable pagingInfo);
 }
 

--- a/seboard/src/main/java/com/seproject/board/post/persistence/PostQueryRepository.java
+++ b/seboard/src/main/java/com/seproject/board/post/persistence/PostQueryRepository.java
@@ -1,14 +1,26 @@
 package com.seproject.board.post.persistence;
 
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.seproject.board.common.Status;
+import com.seproject.board.post.controller.PostSearchOptions;
+import com.seproject.board.post.controller.dto.PostResponse;
+import com.seproject.board.post.controller.dto.PostResponse.RetrievePostListResponseElement;
 import com.seproject.board.post.domain.model.Post;
 import com.seproject.file.domain.model.FileMetaData;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Set;
 
+import static com.fasterxml.jackson.databind.PropertyName.construct;
+import static com.querydsl.core.types.Projections.constructor;
 import static com.seproject.board.menu.domain.QCategory.category;
 import static com.seproject.board.post.domain.model.QPost.post;
 import static com.seproject.member.domain.QBoardUser.boardUser;
@@ -24,12 +36,63 @@ public class PostQueryRepository {
         Post findPost = jpaQueryFactory.select(post)
                 .from(post)
                 .leftJoin(post.category, category).fetchJoin()
+                .leftJoin(post.category.superMenu).fetchJoin()
                 .leftJoin(post.author, boardUser).fetchJoin()
                 .where(post.postId.eq(id))
                 .fetchOne();
 
         Set<FileMetaData> attachments = findPost.getAttachments();
         return findPost;
+    }
+
+
+    public Page<RetrievePostListResponseElement> searchPostList(Long categoryId, PostSearchOptions queryOption, String query, int page, int size) {
+        List<RetrievePostListResponseElement> list = jpaQueryFactory
+                .select(constructor(RetrievePostListResponseElement.class, post))
+                .from(post)
+                .leftJoin(post.category, category)
+                .leftJoin(post.category.superMenu)
+                .leftJoin(post.author, boardUser)
+                .where(categoryEq(categoryId))
+                .where(queryLike(queryOption, query))
+                .where(normalStatusEq())
+                .orderBy(post.baseTime.createdAt.desc())
+                .offset(page)
+                .limit(size)
+                .fetch();
+
+        Long count = jpaQueryFactory
+                .select(post.count())
+                .from(post)
+                .leftJoin(post.category, category)
+                .leftJoin(post.category.superMenu)
+                .leftJoin(post.author, boardUser)
+                .where(categoryEq(categoryId))
+                .where(queryLike(queryOption, query))
+                .where(normalStatusEq())
+                .fetchOne();
+
+        return new PageImpl<>(list, PageRequest.of(page, size), count);
+    }
+
+    private BooleanExpression normalStatusEq() {
+        return post.status.eq(Status.NORMAL);
+    }
+
+    private BooleanExpression queryLike(PostSearchOptions queryOption, String query) {
+        if(query==null || queryOption==null){
+            return null;
+        }
+
+        return queryOption.search(query);
+    }
+
+    private BooleanExpression categoryEq(Long categoryId) {
+        if(categoryId == null){
+            return null;
+        }
+
+        return post.category.menuId.eq(categoryId).or(post.category.superMenu.menuId.eq(categoryId));
     }
 
 }

--- a/seboard/src/main/java/com/seproject/error/errorCode/ErrorCode.java
+++ b/seboard/src/main/java/com/seproject/error/errorCode/ErrorCode.java
@@ -52,6 +52,7 @@ public enum ErrorCode {
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, 201, "올바르지 않은 형식의 요청입니다."),
     INVALID_DATE(HttpStatus.BAD_REQUEST, 202, "올바르지 않은 날짜 정보를 전송하였습니다."),
     INVALID_FILE_SIZE(HttpStatus.BAD_REQUEST, 203, "파일 크기가 너무 큽니다."),
+    INVALID_SEARCH_OPTION(HttpStatus.BAD_REQUEST, 204, "올바르지 않은 검색 옵션입니다."),
 
 
     NOT_EXIST_POST(HttpStatus.NOT_FOUND, 300, "존재하지 않는 게시글입니다."),


### PR DESCRIPTION
before:
    PostSearchJpaRepository의 여러 메소드를 사용하여 검색
    spring data jpa @Query 어노테이션으로 보기 어렵게 구현됨
    동적쿼리 사용이 불가능했음
after:
    QueryDSL구현으로 변경함
    PostQueryRepository의 searchPostList 메소드를 사용하여 검색
    기존에 사용하던 PostSearchJpaRepository는 클래스에서 호출하는
    메소드가 존재하여 남겨두었음

이후 PostSearchJpaRepository의 메소드 또한 queryDSL로 변경해야함