### PR TITLE
fix(DTO) : 이메일을 노출하는 loginId를 userId로 필드 변경

### DIFF
--- a/seboard/src/main/java/com/seproject/account/account/application/AccountAppService.java
+++ b/seboard/src/main/java/com/seproject/account/account/application/AccountAppService.java
@@ -77,13 +77,17 @@ public class AccountAppService {
         Account account = SecurityUtils.getAccount()
                 .orElseThrow(() -> new CustomAuthenticationException(ErrorCode.NOT_LOGIN,null));
 
+        Long accountId = account.getAccountId();
+        Member member = memberService.findByAccountId(accountId);
+
         if(isOAuthUser(account)) {
             String redirectURL = logoutService.getRedirectURL();
-            accountService.deleteAccount(account.getAccountId(), true);
-            return WithDrawResponse.toDTO(account,true,redirectURL);
+            accountService.deleteAccount(accountId, true);
+            return WithDrawResponse.toDTO(account,member,true,redirectURL);
         }
-        accountService.deleteAccount(account.getAccountId() , true);
-        return WithDrawResponse.toDTO(account,false,null);
+
+        accountService.deleteAccount(accountId, true);
+        return WithDrawResponse.toDTO(account,member,false,null);
     }
 
     @Transactional

--- a/seboard/src/main/java/com/seproject/account/account/controller/dto/MyPageDTO.java
+++ b/seboard/src/main/java/com/seproject/account/account/controller/dto/MyPageDTO.java
@@ -14,16 +14,14 @@ public class MyPageDTO {
     @Builder(access = AccessLevel.PRIVATE)
     public static class MyInfoResponse {
         private String nickname;
-
-        // TODO : 필드 변경
-        private Long boardUserId;
+        private Long userId;
         private List<String> roles;
 
         public static MyInfoResponse toDTO(Member findMember,List<String> roles) {
             return builder()
                     .nickname(findMember.getName())
                     .roles(roles)
-                    .boardUserId(findMember.getBoardUserId())
+                    .userId(findMember.getBoardUserId())
                     .build();
         }
     }

--- a/seboard/src/main/java/com/seproject/account/account/controller/dto/WithDrawDTO.java
+++ b/seboard/src/main/java/com/seproject/account/account/controller/dto/WithDrawDTO.java
@@ -3,6 +3,7 @@ package com.seproject.account.account.controller.dto;
 import com.seproject.account.account.domain.Account;
 import com.seproject.account.role.domain.Role;
 import com.seproject.account.role.domain.RoleAccount;
+import com.seproject.member.domain.BoardUser;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
@@ -24,16 +25,16 @@ public class WithDrawDTO {
         private boolean requiredRedirect;
         private String url;
         private Long accountId;
-        private String loginId;
+        private Long userId;
         private List<String> roles;
         private String name;
 
-        public static WithDrawResponse toDTO(Account account, boolean requiredRedirect, String url) {
+        public static WithDrawResponse toDTO(Account account, BoardUser boardUser, boolean requiredRedirect, String url) {
             return builder()
                     .requiredRedirect(requiredRedirect)
                     .url(url)
                     .accountId(account.getAccountId())
-                    .loginId(account.getLoginId())
+                    .userId(boardUser.getBoardUserId())
                     .roles(account.getRoleAccounts().stream()
                             .map(RoleAccount::getRole)
                             .map(Role::toString)

--- a/seboard/src/main/java/com/seproject/admin/account/application/AdminAccountAppService.java
+++ b/seboard/src/main/java/com/seproject/admin/account/application/AdminAccountAppService.java
@@ -29,6 +29,7 @@ import com.seproject.error.errorCode.ErrorCode;
 import com.seproject.error.exception.CustomAccessDeniedException;
 import com.seproject.error.exception.CustomAuthenticationException;
 import com.seproject.error.exception.CustomIllegalArgumentException;
+import com.seproject.member.domain.BoardUser;
 import com.seproject.member.domain.Member;
 import com.seproject.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -104,10 +105,12 @@ public class AdminAccountAppService {
         checkAuthorization(DashBoardMenu.ACCOUNT_MANAGE_URL);
 
         Account account = accountService.findById(accountId);
+        BoardUser boardUser = memberService.findByAccountId(accountId);
         List<RoleDTO.RoleResponse> roles = account.getRoles()
                 .stream().map(RoleDTO.RoleResponse :: of)
                 .collect(Collectors.toList());
-        return AccountResponse.of(account,roles);
+
+        return AccountResponse.of(account,boardUser,roles);
     }
 
     @Transactional

--- a/seboard/src/main/java/com/seproject/admin/account/controller/dto/AdminAccountDto.java
+++ b/seboard/src/main/java/com/seproject/admin/account/controller/dto/AdminAccountDto.java
@@ -2,6 +2,7 @@ package com.seproject.admin.account.controller.dto;
 
 import com.seproject.account.account.domain.Account;
 import com.seproject.admin.role.controller.dto.RoleDTO;
+import com.seproject.member.domain.BoardUser;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
@@ -16,19 +17,19 @@ public class AdminAccountDto {
 
     public static class AccountResponse {
         private Long accountId;
-        private String loginId;
+        private Long userId;
         private String name;
         private String nickname;
         private LocalDateTime registeredDate;
         private List<RoleDTO.RoleResponse> roles;
 
         public AccountResponse(Long accountId,
-                               String loginId,
+                               Long userId,
                                String name,
                                String nickname,
                                LocalDateTime registeredDate) {
             this.accountId = accountId;
-            this.loginId = loginId;
+            this.userId = userId;
             this.name = name;
             this.nickname = nickname;
             this.registeredDate = registeredDate;
@@ -37,24 +38,24 @@ public class AdminAccountDto {
 
         @Builder(access = AccessLevel.PRIVATE)
         public AccountResponse(Long accountId,
-                               String loginId,
+                               Long userId,
                                String name,
                                String nickname,
                                LocalDateTime registeredDate,
                                List<RoleDTO.RoleResponse> roles) {
             this.accountId = accountId;
-            this.loginId = loginId;
+            this.userId = userId;
             this.name = name;
             this.nickname = nickname;
             this.registeredDate = registeredDate;
             this.roles = roles;
         }
 
-        public static AccountResponse of(Account account,List<RoleDTO.RoleResponse> roles) {
+        public static AccountResponse of(Account account, BoardUser boardUser, List<RoleDTO.RoleResponse> roles) {
 
             return builder()
                     .accountId(account.getAccountId())
-                    .loginId(account.getLoginId())
+                    .userId(boardUser.getBoardUserId())
                     .name(account.getName())
                     .registeredDate(account.getCreatedAt())
                     .roles(roles)

--- a/seboard/src/main/java/com/seproject/board/comment/application/dto/CommentCommand.java
+++ b/seboard/src/main/java/com/seproject/board/comment/application/dto/CommentCommand.java
@@ -8,7 +8,6 @@ public class CommentCommand {
     @Builder
     public static class CommentWriteCommand{
         private Long postId;
-        private String loginId;
         private String contents;
         private boolean isAnonymous;
         private boolean isOnlyReadByAuthor;

--- a/seboard/src/main/java/com/seproject/member/controller/dto/UserResponse.java
+++ b/seboard/src/main/java/com/seproject/member/controller/dto/UserResponse.java
@@ -6,16 +6,16 @@ import lombok.Data;
 @Data
 public class UserResponse {
 
-    private String loginId;
+    private Long userId;
     private String name;
 
-    public UserResponse(String loginId, String name) {
-        this.loginId = loginId;
+    public UserResponse(Long userId, String name) {
+        this.userId = userId;
         this.name = name;
     }
 
     public UserResponse(BoardUser boardUser) {
-        this.loginId = boardUser.getLoginId();
+        this.userId = boardUser.getBoardUserId();
         this.name = boardUser.getName();
     }
 }


### PR DESCRIPTION
userId는 Member 엔티티의 memberId를 가져옴

Anonymous -> 다른 사람들에게 노출되지 않음 -> pk가 비즈니스적 의미가 없음
Member -> 다른 사람들에게 노출 가능 -> pk를 통해서 프로필 조회, 수정 가능성 등 비즈니스 로직 의미를 가짐